### PR TITLE
make load patterns optional in end detector

### DIFF
--- a/end_detect.py
+++ b/end_detect.py
@@ -8,7 +8,7 @@ import datetime
 import pytz
 
 
-config = configuration.ConfigurationConnectionEnvVars()
+config = configuration.ConfigurationConnectionEnvVars(require_load_patterns=False)
 DEBOUNCE_PERIOD = int(os.environ['DEBOUNCE_PERIOD'])
 QUERY_WINDOW = int(os.environ['QUERY_WINDOW'])
 POD_DETACH_ADJUSTMENT = int(os.environ['POD_DETACH_ADJUSTMENT'])

--- a/plantd_modeling/configuration.py
+++ b/plantd_modeling/configuration.py
@@ -324,7 +324,7 @@ class Pipeline:
         return p
 
 class ConfigurationConnectionEnvVars:
-    def __init__(self):
+    def __init__(self, require_load_patterns=True):
         self.experiments  = {}
         self.load_patterns = {}
         self.datasets = {}
@@ -355,7 +355,10 @@ class ConfigurationConnectionEnvVars:
             try:
                 exp.load_patterns = {k:self.load_patterns[v] for k,v in exp.load_pattern_names.items()}
             except  KeyError as ke:
-                raise Exception(f"Load patterns of experiment {exp.experiment_name} not found: {ke}")
+                if require_load_patterns:
+                    raise Exception(f"Load patterns of experiment {exp.experiment_name} not found: {ke}")
+                else:
+                    print(f"Load patterns of experiment {exp.experiment_name} not found (but not required): {ke}")
 
         self.scenario = None
         self.netcosts = None


### PR DESCRIPTION
Load patterns are typically sent to the modeling code along with experiments, but in the case of the end detector, they're not used, so it's OK if they're missing.  Don't throw an error in that case.